### PR TITLE
api: provide an api `.fire()` to remove related event from stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Example
 var keypress = require('keypress');
 
 // make `process.stdin` begin emitting "keypress" events
-keypress(process.stdin);
+var state = keypress(process.stdin);
 
 // listen for the "keypress" event
 process.stdin.on('keypress', function (ch, key) {
@@ -49,6 +49,9 @@ process.stdin.on('keypress', function (ch, key) {
 
 process.stdin.setRawMode(true);
 process.stdin.resume();
+
+// remove the `keypress` event emitter
+state.fire();
 ```
 
 #### Listening for "mousepress" events
@@ -64,12 +67,6 @@ keypress.enableMouse(process.stdout);
 
 process.stdin.on('mousepress', function (info) {
   console.log('got "mousepress" event at %d x %d', info.x, info.y);
-});
-
-process.on('exit', function () {
-  // disable mouse on exit, so that the state
-  // is back to normal for the terminal
-  keypress.disableMouse(process.stdout);
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,12 @@ var EventEmitter = require('events').EventEmitter;
 var exports = module.exports = keypress;
 
 /**
+ * Enable Mouse
+ */
+
+var mouseEnabled = false;
+
+/**
  * This module offers the internal "keypress" functionality from node-core's
  * `readline` module, for your own programs and modules to use.
  *
@@ -65,6 +71,16 @@ function keypress(stream) {
   } else {
     stream.on('newListener', onNewListener);
   }
+
+  return {
+    fire: function() {
+      stream.removeListener('newListener', onNewListener);
+      stream.removeListener('data', onData);
+      if (mouseEnabled) {
+        disableMouse();
+      }
+    }
+  };
 }
 
 /**
@@ -104,8 +120,12 @@ function isEmittingKeypress(stream) {
  * @api public
  */
 
-exports.enableMouse = function (stream) {
+exports.enableMouse = function enableMouse(stream) {
+  mouseEnabled = true;
   stream.write('\x1b[?1000h');
+  process.once('exit', function() {
+    exports.disableMouse(stream);
+  });
 };
 
 /**
@@ -117,7 +137,8 @@ exports.enableMouse = function (stream) {
  * @api public
  */
 
-exports.disableMouse = function (stream) {
+exports.disableMouse = function disableMouse(stream) {
+  mouseEnabled = false;
   stream.write('\x1b[?1000l');
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keypress",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Make any Node ReadableStream emit \"keypress\" events",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -18,11 +18,5 @@ process.stdin.on('mousepress', function (mouse) {
 })
 
 keypress.enableMouse(process.stdout)
-process.on('exit', function () {
-  //disable mouse on exit, so that the state is back to normal
-  //for the terminal.
-  keypress.disableMouse(process.stdout)
-})
-
 process.stdin.resume()
 


### PR DESCRIPTION
See the title of this PR, I did:

##### 1. add `.fire()`
this call `removeListener()` to our `onData`/`onNewListener` functions for user, and if user has a specific call to `enableMouse`, it would call `disableMouse()`.

##### 2. remove some unnecessary calls at user-land
for example: user don't need write this:
```js
process.on('exit', function() {
  keypress.disableMouse();
});
```

All what I did just fix some memory leaks on `EventEmitter`.
PS: This module is very awesome, thank you so much :)
