### PR TITLE
Fix octals for strict mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,8 +371,8 @@ function emitKey(stream, s) {
     key.name = 'mouse';
     var s = key.sequence;
     var b = s.charCodeAt(3);
-    key.x = s.charCodeAt(4) - 040;
-    key.y = s.charCodeAt(5) - 040;
+    key.x = s.charCodeAt(4) - parseInt('040', 8);
+    key.y = s.charCodeAt(5) - parseInt('040', 8);
 
     key.scroll = 0;
 


### PR DESCRIPTION
When trying to use keypress in strict mode node complains because of use of octal literals. This PR changes octal literals to a format that works in strict mode.

```
node --use_strict test.js
/Users/alarner/oss/keypress/index.js:375
    key.y = s.charCodeAt(5) - 040;
                              ^^^

SyntaxError: Octal literals are not allowed in strict mode.
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/alarner/oss/keypress/test.js:2:16)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
```